### PR TITLE
Implemented basic permissions for commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/*
 config.js
+permissions.json

--- a/main.js
+++ b/main.js
@@ -1,12 +1,52 @@
 const Discord = require("discord.js");
 const bot = new Discord.Client();
 
+const permissionsFile = './permissions.json'
+
 // check if the config file exists, write it if it doesn't?
 const conf = require('./config');
 console.log(conf);
 
 // Load the commands
 const commands = require('./commands');
+
+// Load the permissions
+var permissions = {};
+try{
+    permissions = require(permissionsFile);
+    console.log('permissions:');
+    console.log(permissions);
+} catch(error){
+    // Unable to load permissions, default to none. Should we quit instead?
+    permissions.global = {};
+    permissions.users = {};
+}
+
+/*
+    Given a user ID, is the user allowed to run the given command.
+    True if allowed globally
+    True if allowed explicitly for user ID but not globally
+    True if not defined globally or per user
+*/
+permissions.isAllowed = function (userId,command){
+    var allowed = null;
+    // Check global permissions
+    if(permissions.global.hasOwnProperty(command)){
+        allowed = permissions.global[command] === true;
+    }
+    if(!allowed){
+        // Check explicit user permissions
+        if(permissions.users[userId]){
+            if(permissions.users[userId].hasOwnProperty(command)){
+                allowed = permissions.users[userId][command] === true;
+            }
+        }
+    }
+    if (allowed===null){
+        allowed = true;
+    }
+    return allowed;
+}
 
 bot.on('ready', () => {
   console.log('I am ready!');
@@ -32,7 +72,12 @@ bot.on("message", msg => {
         let cmd = args.shift().replace(conf.command_prefix, "");
 
         if (commands[cmd]) {
-            commands[cmd](args, msg.channel, msg.author);
+            // Check if the user is allowed to issue the command
+            if (permissions.isAllowed(msg.author.id,cmd)){
+                commands[cmd](args, msg.channel, msg.author);
+            } else {
+                msg.channel.sendMessage(msg.author.username+' is not allowed to use `'+cmd+'`');
+            }
         } else {
             msg.channel.sendMessage("That command isn't yet implemented :(");
         }

--- a/permissions.json.example
+++ b/permissions.json.example
@@ -1,0 +1,15 @@
+{
+    "global":{
+        "command": false,
+        "command2": false
+    },
+    "users":{
+        "userid": {
+            "command" : true,
+            "command2" : true
+            },
+        "anotheruserid": {
+            "command2" : true
+        }
+    }
+}


### PR DESCRIPTION
Permissions can be assigned per command in two ways. If a command is not defined globally or per user in the permissions file it will be allowed. If the command is allowed globally it will over ride the per user permissions. If the command is denied globally but allowed per user, it is allwoed. Users are represented by their user ID.