### PR TITLE
Issue 25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ conf/auth.json
 
 # Legacy
 config.js
+!src/commands/config.js
 auth.json

--- a/src/command.js
+++ b/src/command.js
@@ -1,5 +1,6 @@
 const auditor = require('./auditor.js');
 const permissions = require('./permissions.js');
+const Logger = require('./logger.js');
 
 class Command {
     constructor(msg) {
@@ -60,7 +61,8 @@ class Command {
             return true;
         }
         // Since we are restricted, we need to check if the issuer has permission to run the command
-        return permissions.isAllowedToRun(this.commandName, this.authorRoles, this.guildUsedIn);
+        // if we don't have a particular guild, check all known
+        return this.guildUsedIn ? permissions.isAllowedToRun(this.commandName, this.authorRoles, this.guildUsedIn):permissions.isAllowedToRunSomewhere(this.author.id, this.commandName);
     }
 
     report() {

--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -87,11 +87,11 @@ class config extends Command {
     }
 
     usage () {
-        return this.commandName+' can only be used by direct messaging me. You can use it to look up a config setting or set a new value.\n'+
-        'To look up option `foo`: '+this.commandName+' foo\n'+
-        '*To change the value of foo to bar'+this.commandName+' foo bar\n'+
-        '*Note: it depends on what the option is expecting. strings, integers, booleans should appear as the second argument. Arrays should have each element as its own argument.\n'+
-        '\n Here is a list of config options you can use: '+configuration.getConfigurableOptionNames(protectedValues);
+        return `${this.commandName} can only be used by direct messaging me. You can use it to look up a config setting or set a new value.
+To look up option \`foo\`: ${this.commandName} foo
+*To change the value of foo to bar ${this.commandName} foo bar
+*Note: it depends on what the option is expecting. strings, integers, booleans should appear as the second argument. Arrays should have each element as its own argument.
+Here is a list of config options you can use: ${configuration.getConfigurableOptionNames(protectedValues)}`;
     }
 
 }

--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -1,0 +1,152 @@
+const join = require('path').join;
+const Command = require(join('..','command.js'));
+const configuration = require(join('..','configuration.js'));
+const Logger = require(join('..','logger.js'));
+const permissions = require(join('..','permissions.js'));
+const protectedValues = ['secret_key'];
+
+class config extends Command {
+    constructor(msg) {
+        super(msg);
+        this.restricted = true;
+    }
+
+    logic() {
+        // Confirm we are recciving this in a DM
+        if(this.channel.type!='dm'){
+            Logger.message(this.author, "You can only use this command by messaging me directly!");
+            return;
+        }
+
+        let optionName = '';
+        let optionValue = undefined;
+
+        // We always expect an option name as the first arg
+        if(this.args.length>0){
+            optionName = this.args[0];
+        } else {
+            Logger.message(this.author, this.usage());
+            return;
+        }
+
+        // Confirm the option isn't protected from being modified by this command
+        if(protectedValues.includes(optionName)){
+            Logger.message(this.author, "I'm afraid I can't let you do that Dave. "+optionName+" cannot be modified here.");
+            return;
+        }
+
+        // Confirm that we were given a valid option
+        if(!this.isValidOptionName(optionName)){
+            Logger.message(this.author, '"'+optionName+'" was not a valid option name. Try one of '+this.getConfigurableOptionNames());
+            return;
+        }
+
+        // Only given the option name, show its info
+        if(this.args.length===1){
+            Logger.message(this.author, this.getOptionInfoString(optionName));
+            return;
+        }
+
+        // Determine the expected type for this option
+        let optionType = this.getOptionType(optionName);
+        if(optionType===undefined){
+            // We must know what type we are expecting or we cannot validate
+            Logger.message(this.author, 'Error, type information missing for '+optionName+' in the schema. I cannot determine if your new value is valid for this option.');
+            return;
+        }
+
+        // We must have a valid option name, at least one argument, and know the type of input to expect at this point
+        // We want to look at the remaining args, protect the original args and get rid of the first which is the option name
+        let values = this.args;
+        values.shift();
+        let valueToSet = undefined; // Will hold what we eventually try setting
+
+        if(optionType!=='array'){
+            if(values.length>1){
+                // We were given multiple values for a non array option, invalid
+                Logger.message(this.author, 'Error, I was not expecting more than one value. This option is expecting "'+optionType+'" not an array');
+                return;
+            }
+            valueToSet = this.validateOption(optionType,values[0]);
+        } else {
+            // Make an "array" out of the remaining args. JSON style
+            valueToSet = this.validateOption(optionType,'['+values.join()+']');
+        }
+
+        if(valueToSet){
+            // The value must have passed validation, lets set it
+            let message = optionName+'\nWas: '+configuration.getSetting(optionName);
+            configuration.setSetting(optionName, valueToSet);
+            configuration.save();
+            message += '\nNow: '+configuration.getSetting(optionName);
+            Logger.message(this.author,message);
+        } else {
+            // Value must not have passed validation, don't set
+            Logger.message(this.author, 'Error, I was not able to validate your setting. This option is expecting "'+optionType+'"');
+        }
+    }
+
+    // Filters out options we cannot modify with this command and returns a string of possible options
+    getConfigurableOptionNames(){
+        return configuration.options().filter(o=>!protectedValues.includes(o)).join(", ");
+    }
+
+    // Returns a string of what we know about the given option
+    getOptionInfoString(optionName){
+        if(!this.isValidOptionName(optionName)){
+            return '';
+        }
+        let optionSchema = configuration.getSchema(optionName);
+        let result = optionName + ' = '+configuration.getSetting(optionName);
+        result +='\n\tDescription: ';
+        result += optionSchema.description || 'no description';
+        result +='\n\tType: ';
+        result += optionSchema.type || 'no type';
+        result +='\n\tDefault: ';
+        result += optionSchema.default || 'no default';
+        return result;
+    }
+
+    // Looks at the schema to find the expected type for the option
+    getOptionType(optionName){
+        if(!this.isValidOptionName(optionName)){
+            return undefined;
+        }
+        return configuration.getSchema(optionName).type || undefined
+    }
+
+    // True of the option name given matches one of the known options
+    isValidOptionName(optionName){
+        return configuration.options().find(o => { return o===optionName; }) ? true:false;
+    }
+
+    usage () {
+        return this.commandName+' can only be used by direct messaging me. You can use it to look up a config setting or set a new value.\n'+
+        'To look up option `foo`: '+this.commandName+' foo\n'+
+        '*To change the value of foo to bar'+this.commandName+' foo bar\n'+
+        '*Note: it depends on what the option is expecting. strings, integers, booleans should appear as the second argument. Arrays should have each element as its own argument.\n'+
+        '\n Here is a list of config options you can use: '+this.getConfigurableOptionNames();
+    }
+
+    // Attempts to validate the user input by comparing what we were expecting to what we got
+    validateOption(expectedType, givenValue){
+        switch(expectedType){
+            case 'array':
+                return givenValue.startsWith('[') && givenValue.endsWith(']') ? givenValue:undefined;
+                break; // Yes, I know this is unreachable but it lets me sleep at night. Ok?
+            case 'string':
+                return givenValue;
+                break;
+            case 'boolean':
+                return givenValue.toLowerCase()==='true' || givenValue.toLowerCase()==='false' ? givenValue:undefined;
+                break;
+            case 'integer':
+                return isNaN(parseInt(givenValue)) ? undefined:givenValue;
+                break;
+            default:
+                return undefined;
+        }
+    }
+}
+
+module.exports = config;

--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -36,19 +36,19 @@ class config extends Command {
         }
 
         // Confirm that we were given a valid option
-        if(!this.isValidOptionName(optionName)){
-            Logger.message(this.author, '"'+optionName+'" was not a valid option name. Try one of '+this.getConfigurableOptionNames());
+        if(!configuration.isValidOptionName(optionName)){
+            Logger.message(this.author, '"'+optionName+'" was not a valid option name. Try one of '+configuration.getConfigurableOptionNames(protectedValues));
             return;
         }
 
         // Only given the option name, show its info
         if(this.args.length===1){
-            Logger.message(this.author, this.getOptionInfoString(optionName));
+            Logger.message(this.author, configuration.getOptionInfoString(optionName));
             return;
         }
 
         // Determine the expected type for this option
-        let optionType = this.getOptionType(optionName);
+        let optionType = configuration.getOptionType(optionName);
         if(optionType===undefined){
             // We must know what type we are expecting or we cannot validate
             Logger.message(this.author, 'Error, type information missing for '+optionName+' in the schema. I cannot determine if your new value is valid for this option.');
@@ -67,10 +67,10 @@ class config extends Command {
                 Logger.message(this.author, 'Error, I was not expecting more than one value. This option is expecting "'+optionType+'" not an array');
                 return;
             }
-            valueToSet = this.validateOption(optionType,values[0]);
+            valueToSet = configuration.validateOption(optionType,values[0]);
         } else {
             // Make an "array" out of the remaining args. JSON style
-            valueToSet = this.validateOption(optionType,'['+values.join()+']');
+            valueToSet = configuration.validateOption(optionType,'['+values.join()+']');
         }
 
         if(valueToSet){
@@ -86,67 +86,14 @@ class config extends Command {
         }
     }
 
-    // Filters out options we cannot modify with this command and returns a string of possible options
-    getConfigurableOptionNames(){
-        return configuration.options().filter(o=>!protectedValues.includes(o)).join(", ");
-    }
-
-    // Returns a string of what we know about the given option
-    getOptionInfoString(optionName){
-        if(!this.isValidOptionName(optionName)){
-            return '';
-        }
-        let optionSchema = configuration.getSchema(optionName);
-        let result = optionName + ' = '+configuration.getSetting(optionName);
-        result +='\n\tDescription: ';
-        result += optionSchema.description || 'no description';
-        result +='\n\tType: ';
-        result += optionSchema.type || 'no type';
-        result +='\n\tDefault: ';
-        result += optionSchema.default || 'no default';
-        return result;
-    }
-
-    // Looks at the schema to find the expected type for the option
-    getOptionType(optionName){
-        if(!this.isValidOptionName(optionName)){
-            return undefined;
-        }
-        return configuration.getSchema(optionName).type || undefined
-    }
-
-    // True of the option name given matches one of the known options
-    isValidOptionName(optionName){
-        return configuration.options().find(o => { return o===optionName; }) ? true:false;
-    }
-
     usage () {
         return this.commandName+' can only be used by direct messaging me. You can use it to look up a config setting or set a new value.\n'+
         'To look up option `foo`: '+this.commandName+' foo\n'+
         '*To change the value of foo to bar'+this.commandName+' foo bar\n'+
         '*Note: it depends on what the option is expecting. strings, integers, booleans should appear as the second argument. Arrays should have each element as its own argument.\n'+
-        '\n Here is a list of config options you can use: '+this.getConfigurableOptionNames();
+        '\n Here is a list of config options you can use: '+configuration.getConfigurableOptionNames(protectedValues);
     }
 
-    // Attempts to validate the user input by comparing what we were expecting to what we got
-    validateOption(expectedType, givenValue){
-        switch(expectedType){
-            case 'array':
-                return givenValue.startsWith('[') && givenValue.endsWith(']') ? givenValue:undefined;
-                break; // Yes, I know this is unreachable but it lets me sleep at night. Ok?
-            case 'string':
-                return givenValue;
-                break;
-            case 'boolean':
-                return givenValue.toLowerCase()==='true' || givenValue.toLowerCase()==='false' ? givenValue:undefined;
-                break;
-            case 'integer':
-                return isNaN(parseInt(givenValue)) ? undefined:givenValue;
-                break;
-            default:
-                return undefined;
-        }
-    }
 }
 
 module.exports = config;

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -83,13 +83,6 @@ class Configuration {
     }
 
     setSetting(option, value) {
-        if(!this.isValidOptionName(option)){
-            return false;
-        }
-        value = this.validateOption(this.getOptionType(option),value);
-        if(value===undefined){
-            return false;
-        }
         this.data.set(option, value);
         return true;
     }

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -86,7 +86,7 @@ class Configuration {
         if(!this.isValidOptionName(option)){
             return false;
         }
-        value = this.validateOption(value);
+        value = this.validateOption(this.getOptionType(option),value);
         if(value===undefined){
             return false;
         }

--- a/src/interface.js
+++ b/src/interface.js
@@ -17,12 +17,15 @@ class Interface {
         this.in.setPrompt(prefix, prefix.length);
 
         this.in.on(
-            'line', 
-            function(cmd) {
+            'line',
+            function(input) {
                 let repeat = true;
+                input = input.split(" ");
+                let cmd = input.shift();
+                let args = input;
                 if (cmd !== 'stop' && cmd !== 'start' && this[cmd]) {
                     // TODO: Implement a better way to map this
-                    repeat = this[cmd]();
+                    repeat = this[cmd](args);
                 }
                 if (repeat) {
                     this.in.prompt();

--- a/src/interface.js
+++ b/src/interface.js
@@ -10,7 +10,7 @@ class Interface {
     }
 
     start() {
-        console.log("Bringing up the user interface...");
+        Logger.log("Bringing up the user interface...");
         this.in = readline.createInterface({
             input: process.stdin,
             output: process.stdout
@@ -36,7 +36,7 @@ class Interface {
             }.bind(this)
         ).on(
             'close',
-            () => console.log('Closing user interface')
+            () => Logger.log('Closing user interface')
         );
         this.in.prompt();
     }
@@ -108,7 +108,7 @@ class Interface {
     }
 
     help() {
-        console.log(`
+        Logger.log(`
 
 [Available Commands]
 'config'

--- a/src/interface.js
+++ b/src/interface.js
@@ -53,10 +53,10 @@ class Interface {
             optionName = args[0];
         } else {
 
-            Logger.log('To look up option `foo`: config foo\n'+
-            '*To change the value of foo to bar: config foo bar\n'+
-            '*Note: it depends on what the option is expecting. strings, integers, booleans should appear as the second argument. Arrays should have each element as its own argument.\n'+
-            '\n Here is a list of config options you can use: '+configuration.getConfigurableOptionNames());
+            Logger.log(`To look up option \`foo\`: config foo
+*To change the value of foo to bar: config foo bar
+*Note: it depends on what the option is expecting. strings, integers, booleans should appear as the second argument. Arrays should have each element as its own argument.
+Here is a list of config options you can use: ${configuration.getConfigurableOptionNames()}`);
             return true;
         }
         // Confirm that we were given a valid option

--- a/src/permissions.js
+++ b/src/permissions.js
@@ -89,10 +89,13 @@ class Permissions extends EventEmitter {
         // Look in all of the bots guilds for the Author Id so we can obtain their GuildMember
         // object which allows us to get their roles. With their roles in each guild, determine
         // if any of them allow them to issue this command
-        return bootstrap.durendal.bot.guilds.filter(g=>g.members.find('id',authorId)).reduce((members,guild)=> {
+        return bootstrap.durendal.bot.guilds.filter(g=>g.members.find('id',authorId))
+        .reduce((members,guild)=> {
             members.push(guild.members.find('id',authorId));
             return members;
-            }, []).find(m=>this.isAllowedToRun(commandName, m.roles,m.guild)) ? true:false;
+            }, [])
+            .find(m=>this.isAllowedToRun(commandName, m.roles,m.guild))
+        ? true:false;
     }
 
     removeCommandFromRole(guildId, commandName, roleId, userId){

--- a/src/permissions.js
+++ b/src/permissions.js
@@ -85,6 +85,16 @@ class Permissions extends EventEmitter {
         return false;
     }
 
+    isAllowedToRunSomewhere(authorId, commandName){
+        // Look in all of the bots guilds for the Author Id so we can obtain their GuildMember
+        // object which allows us to get their roles. With their roles in each guild, determine
+        // if any of them allow them to issue this command
+        return bootstrap.durendal.bot.guilds.filter(g=>g.members.find('id',authorId)).reduce((members,guild)=> {
+            members.push(guild.members.find('id',authorId));
+            return members;
+            }, []).find(m=>this.isAllowedToRun(commandName, m.roles,m.guild)) ? true:false;
+    }
+
     removeCommandFromRole(guildId, commandName, roleId, userId){
         let changed = false;
         let guild = this.getGuildById(guildId); // Get the guild obj


### PR DESCRIPTION
Implements functionality requested in #25. I could be convinced to extend this to the interface as well. However, this on the fly reloading brings up another issue. What if we change something like the `permissions_file`, we'd need to reload the permissions too. I'm thinking any config change emits a bot restart event who must be refactored to reload everything, not just the config. I believe this is beyond the scope of this PR though and should be tracked independently.